### PR TITLE
ci: switch to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, linux, x64]
-    # Foundry (forge, anvil, cast) is pre-installed on the self-hosted runner.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Build
         run: forge build

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -9,14 +9,16 @@ on:
 
 jobs:
   slither:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     # Informational only — does not block merges
-    # Foundry is pre-installed on the self-hosted runner.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Build (required for Slither)
         run: forge build --build-info


### PR DESCRIPTION
Switch remit-protocol CI from self-hosted to free GitHub-hosted runners.

## Changes
- `ci.yml`: `runs-on: ubuntu-latest` + `foundry-rs/foundry-toolchain@v1` action
- `slither.yml`: `runs-on: ubuntu-latest` + Foundry setup step

remit-protocol is a public repo — GitHub Actions is completely free, no minute quotas.